### PR TITLE
Create SBT builds for all Java, Scala and Kotlin projects

### DIFF
--- a/JavaAndroid/build.sbt
+++ b/JavaAndroid/build.sbt
@@ -1,0 +1,5 @@
+lazy val app = project.in(file("app")).settings(androidBuild).settings(
+  platformTarget := "android-23",
+  libraryDependencies += "com.android.support" % "appcompat-v7" % "23.1.1",
+  javacOptions in Compile ++= "-source" :: "1.7" :: "-target" :: "1.7" :: Nil
+)

--- a/JavaAndroid/project/build.properties
+++ b/JavaAndroid/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11

--- a/JavaAndroid/project/build.sbt
+++ b/JavaAndroid/project/build.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-android" % "sbt-android" % "1.6.1")

--- a/KotlinAndroid/build.sbt
+++ b/KotlinAndroid/build.sbt
@@ -1,0 +1,18 @@
+lazy val androidClasspath = taskKey[Classpath]("android classpath")
+
+lazy val app = project.in(file("app")).settings(androidBuild).settings(
+  platformTarget := "android-23",
+  libraryDependencies += "com.android.support" % "appcompat-v7" % "23.1.1",
+  javacOptions in Compile ++= "-source" :: "1.7" :: "-target" :: "1.7" :: Nil,
+  kotlincPluginOptions in Compile ++= {
+    val plugin = KotlinPluginOptions("org.jetbrains.kotlin.android")
+    val layout = (projectLayout in Android).value
+    plugin.option("package", applicationId.value) ::
+    plugin.option("variant", "main;" + layout.res.getCanonicalPath) ::
+      Nil
+  },
+  androidClasspath := (bootClasspath in Android).value,
+  kotlinClasspath(Compile, androidClasspath),
+  kotlinPlugin("android-extensions"),
+  kotlinLib("stdlib")
+)

--- a/KotlinAndroid/project/build.properties
+++ b/KotlinAndroid/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11

--- a/KotlinAndroid/project/build.sbt
+++ b/KotlinAndroid/project/build.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.scala-android" % "sbt-android" % "1.6.1")
+addSbtPlugin("com.hanhuy.sbt" % "kotlin-plugin" % "1.0.0")

--- a/ScalaAndroid/build.sbt
+++ b/ScalaAndroid/build.sbt
@@ -1,0 +1,5 @@
+lazy val app = project.in(file("app")).settings(androidBuild).settings(
+  platformTarget := "android-23",
+  libraryDependencies += "com.android.support" % "appcompat-v7" % "23.1.1",
+  javacOptions in Compile ++= "-source" :: "1.7" :: "-target" :: "1.7" :: Nil
+)

--- a/ScalaAndroid/project/build.properties
+++ b/ScalaAndroid/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11

--- a/ScalaAndroid/project/build.sbt
+++ b/ScalaAndroid/project/build.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-android" % "sbt-android" % "1.6.1")


### PR DESCRIPTION
Created an SBT build for all 3 languages, I could have used [sbt-android-gradle](https://github.com/scala-android/sbt-android/blob/master/GRADLE.md) but I wanted to demonstrate the full sbt experience: shorter build files, faster builds. Fixes #1

java 8 seconds
kotlin 15 seconds
scala 18 seconds

Full output included below

java

```
[pfnguyen@galactica AndroidDemoIn4Languages] $ cd JavaAndroid/
[pfnguyen@galactica JavaAndroid] $ sbt app/clean app/android:package
[info] Loading global plugins from C:\Users\pfnguyen\.sbt\0.13\plugins
[info] Loading project definition from C:\Users\pfnguyen\src\AndroidDemoIn4Languages\JavaAndroid\project
Resolving default:javaandroid-build:0.1-SNAPSHOT
Resolution done
Fetching artifacts
Fetching artifacts: done
[info] Set current project to javaandroid (in build file:/C:/Users/pfnguyen/src/AndroidDemoIn4Languages/JavaAndroid/)
[success] Total time: 0 s, completed May 5, 2016 10:55:32 AM
Resolving app:app:0.1-SNAPSHOT
Resolution done
Fetching artifacts
Fetching artifacts: done
[info] Collecting resources
[info] Performing full resource merge
[info] Processing resources
[info] Rebuilding all classes because R.java has changed
[info] Compiling 6 Java sources to C:\Users\pfnguyen\src\AndroidDemoIn4Languages\JavaAndroid\app\target\android\intermediates\classes...
[info] Packaging C:\Users\pfnguyen\src\AndroidDemoIn4Languages\JavaAndroid\app\target\android\intermediates\classes.jar ...
[info] Packaging resources: resources-debug.ap_
[info] Done packaging.
[info] Generating dex, incremental=true, multidex=false
[warn] Android SDK updates available, run 'android:update-sdk' to update:
[warn]     Intel x86 Atom System Image
[warn]     Google APIs Intel x86 Atom_64 System Image
[warn]     Intel x86 Atom_64 System Image
[warn]     Intel x86 Atom System Image
[warn]     Intel x86 Atom_64 System Image
[warn]     Intel x86 Atom_64 System Image
[warn]     Intel x86 Atom System Image
[warn]     Intel x86 Atom System Image
[warn]     Google APIs Intel x86 Atom System Image
[info] dex method count: 15676
[info] Packaged: app-debug-unaligned.apk (1.10MB)
[info] Debug package does not need signing: app-debug-unaligned.apk
[info] zipaligned: app-debug.apk
[success] Total time: 8 s, completed May 5, 2016 10:55:41 AM
```

kotlin

```
[pfnguyen@galactica JavaAndroid] $ cd ../KotlinAndroid/
[pfnguyen@galactica KotlinAndroid] $ sbt app/clean app/android:package
[info] Loading global plugins from C:\Users\pfnguyen\.sbt\0.13\plugins
[info] Loading project definition from C:\Users\pfnguyen\src\AndroidDemoIn4Languages\KotlinAndroid\project
Resolving default:kotlinandroid-build:0.1-SNAPSHOT
Resolution done
Fetching artifacts
Fetching artifacts: done
[info] Set current project to kotlinandroid (in build file:/C:/Users/pfnguyen/src/AndroidDemoIn4Languages/KotlinAndroid/)
[success] Total time: 0 s, completed May 5, 2016 10:56:01 AM
Resolving app:app:0.1-SNAPSHOT
Resolution done
Fetching artifacts
Fetching artifacts: done
[info] Collecting resources
[info] Performing full resource merge
[info] Processing resources
[warn] Android SDK updates available, run 'android:update-sdk' to update:
[warn]     Intel x86 Atom System Image
[warn]     Intel x86 Atom System Image
[warn]     Intel x86 Atom System Image
[warn]     Intel x86 Atom System Image
[warn]     Intel x86 Atom_64 System Image
[warn]     Intel x86 Atom_64 System Image
[warn]     Google APIs Intel x86 Atom_64 System Image
[warn]     Intel x86 Atom_64 System Image
[warn]     Google APIs Intel x86 Atom System Image
[info] Rebuilding all classes because R.java has changed
[info] Compiling 3 Kotlin sources
[warn] Variable 'holder' initializer is redundant
[info] Compiling 3 Java sources to C:\Users\pfnguyen\src\AndroidDemoIn4Languages\KotlinAndroid\app\target\android\intermediates\classes...
[info] Packaging C:\Users\pfnguyen\src\AndroidDemoIn4Languages\KotlinAndroid\app\target\android\intermediates\classes.jar ...
[info] Packaging resources: resources-debug.ap_
[info] Done packaging.
[info] Generating dex, incremental=true, multidex=false
[info] dex method count: 23185
[info] Packaged: app-debug-unaligned.apk (1.50MB)
[info] Debug package does not need signing: app-debug-unaligned.apk
[info] zipaligned: app-debug.apk
[success] Total time: 15 s, completed May 5, 2016 10:56:16 AM
```

scala

```
[pfnguyen@galactica KotlinAndroid] $ cd ../ScalaAndroid/
[pfnguyen@galactica ScalaAndroid] $ sbt app/clean app/android:package
[info] Loading global plugins from C:\Users\pfnguyen\.sbt\0.13\plugins
[info] Loading project definition from C:\Users\pfnguyen\src\AndroidDemoIn4Languages\ScalaAndroid\project
Resolving default:scalaandroid-build:0.1-SNAPSHOT
Resolution done
Fetching artifacts
Fetching artifacts: done
[info] Set current project to scalaandroid (in build file:/C:/Users/pfnguyen/src/AndroidDemoIn4Languages/ScalaAndroid/)
[success] Total time: 0 s, completed May 5, 2016 11:00:17 AM
Resolving app:app_2.10:0.1-SNAPSHOT
Resolution done
Fetching artifacts
Fetching artifacts: done
[info] Collecting resources
[info] Performing full resource merge
[info] Processing resources
[info] Rebuilding all classes because R.java has changed
[info] Regenerating TR.scala because R.java has changed
[warn] action_bar_root was reassigned: android.support.v7.widget.FitWindowsLinearLayout => android.support.v7.widget.FitWindowsFrameLayout
[warn] status_bar_latest_event_content was reassigned: android.widget.RelativeLayout => android.widget.RelativeLayout => android.widget.LinearLayout
[info] Compiling 4 Scala sources and 4 Java sources to C:\Users\pfnguyen\src\AndroidDemoIn4Languages\ScalaAndroid\app\target\android\intermediates\classes...
[error] [NewApi] target\android\intermediates\classes\com\bookislife\android\scalademo\TypedResource$$anon$2.class:Call requires API level 11 (current min is 9): android.animation.AnimatorInflater#loadAnimator
[error] lint found 1 error, 0 warnings
[info] Packaging C:\Users\pfnguyen\src\AndroidDemoIn4Languages\ScalaAndroid\app\target\android\intermediates\classes.jar ...
[info] Packaging resources: resources-debug.ap_
[info] Done packaging.
[info] Finding dependency references for: com.android.support:support-annotations:23.1.1:default
[info] Finding dependency references for: com.android.support:support-v4:23.1.1 [info] Finding dependency references for: com.android.support:appcompat-v7:23.1.1
[info] Finding dependency references for: com.android.support:support-v4:23.1.1 ProGuard, version 5.0
ProGuard is released under the GNU General Public License. You therefore
must ensure that programs that link to it (android, ...)
carry the GNU General Public License as well. Alternatively, you can
apply for an exception with the author of ProGuard.
Reading input...
Reading program jar [C:\Users\pfnguyen\android-sdk-windows\extras\android\m2repository\com\android\support\support-annotations\23.1.1\support-annotations-23.1.1.jar] (filtered)
Reading program jar [C:\Users\pfnguyen\.android\sbt\exploded-aars\com.android.support-support-v4-23.1.1\libs\internal_impl-23.1.1.jar] (filtered)
Reading program jar [C:\Users\pfnguyen\.android\sbt\exploded-aars\com.android.support-appcompat-v7-23.1.1\com.android.support-appcompat-v7-23.1.1.jar] (filtered)
Reading program jar [C:\Users\pfnguyen\.coursier\cache\v1\https\repo1.maven.org\maven2\org\scala-lang\scala-library\2.10.6\scala-library-2.10.6.jar] (filtered) Reading program jar [C:\Users\pfnguyen\.android\sbt\exploded-aars\com.android.support-support-v4-23.1.1\com.android.support-support-v4-23.1.1.jar] (filtered)
Reading program jar [C:\Users\pfnguyen\src\AndroidDemoIn4Languages\ScalaAndroid\app\target\android\intermediates\classes.jar] (filtered)
Reading library jar [C:\Users\pfnguyen\android-sdk-windows\platforms\android-23\android.jar]
Reading library jar [C:\Users\pfnguyen\android-sdk-windows\platforms\android-23\optional\org.apache.http.legacy.jar]
Initializing...
Ignoring unused library classes...
  Original number of library classes: 3880
  Final number of library classes:    988
Shrinking...
[warn] java.net.UnknownHostException: dl.google.com
[warn] Android SDK updates available, run 'android:update-sdk' to update:
[warn]     Intel x86 Atom System Image
[warn]     Intel x86 Atom System Image
[warn]     Google APIs Intel x86 Atom System Image
[warn]     Intel x86 Atom System Image
[warn]     Intel x86 Atom_64 System Image
[warn]     Intel x86 Atom_64 System Image
[warn]     Google APIs Intel x86 Atom_64 System Image
[warn]     Intel x86 Atom_64 System Image
[warn]     Intel x86 Atom System Image
Removing unused program classes and class elements...
  Original number of program classes: 6439
  Final number of program classes:    1323
Writing output...
Preparing output jar [C:\Users\pfnguyen\src\AndroidDemoIn4Languages\ScalaAndroid\app\target\android\intermediates\proguard\classes.proguard.jar]
  Copying resources from program jar [C:\Users\pfnguyen\android-sdk-windows\extras\android\m2repository\com\android\support\support-annotations\23.1.1\support-annotations-23.1.1.jar] (filtered)
  Copying resources from program jar [C:\Users\pfnguyen\.android\sbt\exploded-aars\com.android.support-support-v4-23.1.1\libs\internal_impl-23.1.1.jar] (filtered)
  Copying resources from program jar [C:\Users\pfnguyen\.android\sbt\exploded-aars\com.android.support-appcompat-v7-23.1.1\com.android.support-appcompat-v7-23.1.1.jar] (filtered)
  Copying resources from program jar [C:\Users\pfnguyen\.coursier\cache\v1\https\repo1.maven.org\maven2\org\scala-lang\scala-library\2.10.6\scala-library-2.10.6.jar] (filtered)
  Copying resources from program jar [C:\Users\pfnguyen\.android\sbt\exploded-aars\com.android.support-support-v4-23.1.1\com.android.support-support-v4-23.1.1.jar] (filtered)
  Copying resources from program jar [C:\Users\pfnguyen\src\AndroidDemoIn4Languages\ScalaAndroid\app\target\android\intermediates\classes.jar] (filtered)
[info] Creating proguard cache: proguard-cache-f75b3a6d5279987c664b74dc929a9f07ade81fe1.jar
[info] Generating dex, incremental=false, multidex=false
[info] dex method count: 11536
[info] Packaged: app-debug-unaligned.apk (946.57KB)
[info] Debug package does not need signing: app-debug-unaligned.apk
[info] zipaligned: app-debug.apk
[success] Total time: 18 s, completed May 5, 2016 11:00:35 AM
```
